### PR TITLE
Ajustar dimensiones canvas para pintar correctamente

### DIFF
--- a/PWA-Signos/src/components/Canvas.jsx
+++ b/PWA-Signos/src/components/Canvas.jsx
@@ -17,8 +17,9 @@ const Canvas = (isLoading, dispatch) => {
         const canvasOffsetY = canvas.offsetTop;
         const canvasMarginTop = 10;
 
-        canvas.width = window.innerWidth - canvasOffsetX * 2;
-        canvas.height = window.innerHeight - canvasOffsetY * 2 - canvasMarginTop;
+        const rect = canvas.getBoundingClientRect();
+        canvas.width = rect.width;
+        canvas.height = rect.height;
 
         let drawing = false;
 

--- a/PWA-Signos/src/components/Canvas.jsx
+++ b/PWA-Signos/src/components/Canvas.jsx
@@ -13,13 +13,21 @@ const Canvas = (isLoading, dispatch) => {
 
         const ctx = canvas.getContext("2d");
 
-        const canvasOffsetX = canvas.offsetLeft;
-        const canvasOffsetY = canvas.offsetTop;
+        let canvasOffsetX = canvas.offsetLeft;
+        let canvasOffsetY = canvas.offsetTop;
         const canvasMarginTop = 10;
 
-        const rect = canvas.getBoundingClientRect();
+        let rect = canvas.getBoundingClientRect();
         canvas.width = rect.width;
         canvas.height = rect.height;
+
+        window.onresize = () => {
+            canvasOffsetX = canvas.offsetLeft;
+            canvasOffsetY = canvas.offsetTop;
+            rect = canvas.getBoundingClientRect();
+            canvas.width = rect.width;
+            canvas.height = rect.height;
+        }
 
         let drawing = false;
 


### PR DESCRIPTION
Fixes #26 

La clave es que si las dimensiones "internas" (pixeles) del canvas no coinciden con las reales después de aplicar el css, el dibujo aparece distorsionado.

Lo he probado un poco y creo que va, probad vosotros también.